### PR TITLE
Fix:Kakao 관련 API 반환 포맷 변경

### DIFF
--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,8 +1,7 @@
 REACT_APP_CLIENT_ID=c99cdf4885e7223c1e66e3060d56b9aac2dd5927b765593c669c78613a5b679d
 REACT_APP_CLIENT_SERECT=d49df9404304e2bff0365eaec854556af2ce711706f7498caed2d1d5cdd882b3
-REACT_APP_REDIECT_URL=https://42chelin.shop/login
+REACT_APP_REDIECT_URL=https://42chelin.shop/register
 REACT_APP_INTRA=https://api.intra.42.fr/
 REACT_APP_HOME=https://42chelin.shop
-REACT_APP_BACKEND_ENDPOINT_URL=https://d2d5oodqrc.execute-api.ap-northeast-2.amazonaws.com/Stage
-REACT_APP_GET_TOKEN=get-token
+REACT_APP_BACKEND_ENDPOINT_URL=https://3d7hb3t7vg.execute-api.ap-northeast-2.amazonaws.com/Prod
 REACT_APP_JWT_SECRET_KEY=42chelin_jwt

--- a/frontend/src/lib/api/kakao.js
+++ b/frontend/src/lib/api/kakao.js
@@ -15,7 +15,7 @@ export const getStoreInfoKakao = async (request) => {
         storeName: request.placeName,
       },
     });
-    return res.data.body;
+    return res.data;
   } catch (error) {
     return Promise.reject(error);
   }

--- a/frontend/src/pages/KakaoSearchPage.js
+++ b/frontend/src/pages/KakaoSearchPage.js
@@ -60,7 +60,7 @@ const KakaoSearchPage = () => {
   const SearchStoreEvent = async () => {
     try {
       const res = await fetchKakaoApi(text);
-      const data = res.data.body;
+      const data = res.data;
       setSearchstoreList(data);
     } catch (e) {
       alert(e.response.data.message);


### PR DESCRIPTION
1. Kakao API를 사용하는 람다 반환 포맷에서 body:{body:data}와 같이 불필요하게 중첩객체로 반환되는 포맷을 변경